### PR TITLE
fix: mainpage to detailpage click event error

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -12,7 +12,7 @@ export const getUserPosts = (req) => {};
 export const getPost = async (postId) => {
   const res = await api.get("/posts");
   console.log(res);
-  const post = res.filter((post) => post.postId === postId);
+  const post = Array.from(res).filter((post) => post.postId === postId);
   return post;
 };
 


### PR DESCRIPTION
## 메인페이지 >> 상세페이지 클릭 이벤트 에러
원인: 객체에 filter메서드를 사용할 수 없음
`Array.from(res)` 로 배열을 만들어 해결